### PR TITLE
Add unique community shortname to ffGeoJson.json

### DIFF
--- a/collector/collectCommunities.py
+++ b/collector/collectCommunities.py
@@ -140,6 +140,7 @@ def geoJson(summary, geoJsonPath):
 			properties['mtime'] = details['state']['lastchange']
 			if 'logo' in details['state']:
 				properties['logo'] = details['state']['logo']
+			properties['shortname'] = community
 		except BaseException as e:
 			log(1, "There's something wrong with the JSON file: " + str(e))
 			continue


### PR DESCRIPTION
This is to identify the community target so that community-specific event could be performed in the cmap (e.g : add community blog post to popup https://github.com/fossasia/api.fossasia.net/issues/44)